### PR TITLE
Run internal app even when SD detected

### DIFF
--- a/_loader/LOADER/LOADER/src/main.cpp
+++ b/_loader/LOADER/LOADER/src/main.cpp
@@ -1406,6 +1406,13 @@ int main()
 	if (!loader && ConfigGetScreenSaver()) BootScreenSaver();
 #endif
 
+	// run embedded application even if SD card is present
+	if (!loader && CheckApp(NULL, NULL, NULL))
+	{
+		RunApp();
+	}
+
+
 	// clear screen
 	memset(FrameBuf, 0, sizeof(FrameBuf));
 	DispDirtyAll();
@@ -1426,8 +1433,7 @@ int main()
 	// try to mount disk
 	if (!DiskMount())
 	{
-		// cannot mount disk, try to run current application ... not if watchdog reset from application
-		if (!loader && CheckApp(NULL, NULL, NULL)) RunApp();
+		// SD mount failed
 	}
 	else
 	{


### PR DESCRIPTION
## Summary
- Ensure boot loader launches the internal application even if an SD card is present.
- Documented SD mount failure path.

## Testing
- `make` *(fails: No rule to make target '../../../_devices//_makefile.inc')*

------
https://chatgpt.com/codex/tasks/task_e_68a1737a8d848323949385df32fe6969