### PR TITLE
Configure NES emulator for 240x240 ST7789 display

### DIFF
--- a/PicoPad/EMU/NES/config.h
+++ b/PicoPad/EMU/NES/config.h
@@ -48,6 +48,16 @@
 #define USE_FRAMEBUF		0		// do not use pre-defined Frame buffer
 #endif // USE_PICOPADHSTX
 
+#define USE_DISPHSTXMINI        0       // 0=do not use HSTX Display Mini driver
+#define USE_DISPHSTX            0       // 0=do not use HSTX Display driver
+#define DISPHSTX_USE_DVI        0       // 0=disable DVI (HDMI) support
+#define DISPHSTX_USE_VGA        0       // 0=disable VGA support
+
+// Configure built-in ST7789 LCD
+#define USE_ST7789              1       // use ST7789 display driver
+#define WIDTH                   240     // display width
+#define HEIGHT                  240     // display height
+
 //#define FONT			FontBold8x8	// default system font
 //#define FONTW			8		// width of system font
 //#define FONTH			8		// height of system font


### PR DESCRIPTION
## Summary
- disable HSTX outputs and enable ST7789 driver
- set NES emulator display size to 240x240 for PicoPad

## Testing
- `TARGET="NES" GRPDIR="EMU" MEMMAP="" bash ../../../_c1.sh` *(fails: arm-none-eabi-gcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a255ab9f448323a60922831f5109c1