### PR TITLE
Reduce NES menu font size for 240x240 screen

### DIFF
--- a/PicoPad/EMU/NES/src/emu_nes_msg.cpp
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.cpp
@@ -136,6 +136,8 @@ void NES_TextUpdate()
         u16 bg = NES_TextBgColor;
         int scaled = EMU_LCD_WIDTH * NES_TEXT_SCALE / 100;
         int pad = EMU_LCD_WIDTH - scaled;
+        int padleft = pad/2;
+        int padright = pad - padleft;
         int rep = scaled / (NES_MSG_WIDTH*8);
         int rem = scaled % (NES_MSG_WIDTH*8);
 
@@ -148,6 +150,8 @@ void NES_TextUpdate()
                 cc = *c; // color of the row
                 s2 = s; // start of text row
                 int acc = 0;
+
+                for (int n = padleft; n > 0; n--) DispSendImg2(bg);
 
                 // columns
                 for (col = 0; col < NES_MSG_WIDTH; col++)
@@ -174,7 +178,7 @@ void NES_TextUpdate()
                         }
                 }
 
-                for (int n = pad; n > 0; n--) DispSendImg2(bg);
+                for (int n = padright; n > 0; n--) DispSendImg2(bg);
 
                 // increase line
                 line++;

--- a/PicoPad/EMU/NES/src/emu_nes_msg.cpp
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.cpp
@@ -16,8 +16,8 @@
 
 #include "../include.h"
 
-#define EMU_LCD_WIDTH	WIDTH	// LCD display width
-#define EMU_LCD_HEIGHT	HEIGHT	// LCD display height
+#define EMU_LCD_WIDTH   NES_LCD_WIDTH	// LCD display width
+#define EMU_LCD_HEIGHT  NES_LCD_HEIGHT	// LCD display height
 
 // text screen buffer (only characters; 176 bytes)
 u8 NES_TextFrame[NES_MSG_WIDTH*NES_MSG_HEIGHT];
@@ -134,8 +134,8 @@ void NES_TextUpdate()
         u8* s2;
         const u8* f = FontBold8x16;
         u16 bg = NES_TextBgColor;
-        int rep = WIDTH / (NES_MSG_WIDTH*8);
-        int rem = WIDTH % (NES_MSG_WIDTH*8);
+        int rep = EMU_LCD_WIDTH / (NES_MSG_WIDTH*8);
+        int rem = EMU_LCD_WIDTH % (NES_MSG_WIDTH*8);
 
         // start sending image data
         DispStartImg(0, EMU_LCD_WIDTH, 0, EMU_LCD_HEIGHT);

--- a/PicoPad/EMU/NES/src/emu_nes_msg.cpp
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.cpp
@@ -134,8 +134,10 @@ void NES_TextUpdate()
         u8* s2;
         const u8* f = FontBold8x16;
         u16 bg = NES_TextBgColor;
-        int rep = EMU_LCD_WIDTH / (NES_MSG_WIDTH*8);
-        int rem = EMU_LCD_WIDTH % (NES_MSG_WIDTH*8);
+        int scaled = EMU_LCD_WIDTH * NES_TEXT_SCALE / 100;
+        int pad = EMU_LCD_WIDTH - scaled;
+        int rep = scaled / (NES_MSG_WIDTH*8);
+        int rem = scaled % (NES_MSG_WIDTH*8);
 
         // start sending image data
         DispStartImg(0, EMU_LCD_WIDTH, 0, EMU_LCD_HEIGHT);
@@ -171,6 +173,9 @@ void NES_TextUpdate()
                                 ch <<= 1;
                         }
                 }
+
+                for (int n = pad; n > 0; n--) DispSendImg2(bg);
+
                 // increase line
                 line++;
 

--- a/PicoPad/EMU/NES/src/emu_nes_msg.h
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.h
@@ -14,9 +14,22 @@
 //	This source code is freely available for any purpose, including commercial.
 //	It is possible to take and modify the code or parts of it, without restriction.
 
-#define NES_MSG_WIDTH   (WIDTH*16/240)  // message text width (~5% smaller, ~15 px per char)
-#define NES_MSG_HEIGHT  11              // message text height of window, 4 rows height 32, 7 rows height 16
-#define NES_MSG_BTMLINE (4*32)          // bottom line to start 16-line rows
+// limit text rendering to 240x240 even if global WIDTH/HEIGHT are larger
+#if WIDTH > 240
+#define NES_LCD_WIDTH   240
+#else
+#define NES_LCD_WIDTH   WIDTH
+#endif
+
+#if HEIGHT > 240
+#define NES_LCD_HEIGHT  240
+#else
+#define NES_LCD_HEIGHT  HEIGHT
+#endif
+
+#define NES_MSG_WIDTH   (NES_LCD_WIDTH*16/240) // message text width (~5% smaller, ~15 px per char)
+#define NES_MSG_HEIGHT  11                     // message text height of window, 4 rows height 32, 7 rows height 16
+#define NES_MSG_BTMLINE (4*32)                 // bottom line to start 16-line rows
 
 // text screen buffer (only characters; 176 bytes)
 extern u8 NES_TextFrame[NES_MSG_WIDTH*NES_MSG_HEIGHT];

--- a/PicoPad/EMU/NES/src/emu_nes_msg.h
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.h
@@ -18,6 +18,9 @@
 #define NES_MSG_HEIGHT	11		// message text height of window, 4 rows height 32, 7 rows height 16
 #define NES_MSG_BTMLINE	(4*32)		// bottom line to start 16-line rows
 
+// text scale in percent (100 = original size)
+#define NES_TEXT_SCALE	95
+
 // text screen buffer (only characters; 160 bytes)
 extern u8 NES_TextFrame[NES_MSG_WIDTH*NES_MSG_HEIGHT];
 

--- a/PicoPad/EMU/NES/src/emu_nes_msg.h
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.h
@@ -14,14 +14,11 @@
 //	This source code is freely available for any purpose, including commercial.
 //	It is possible to take and modify the code or parts of it, without restriction.
 
-#define NES_MSG_WIDTH	(WIDTH/(2*8))	// message text width of window (1 character = 16 pixels width; = 20)
-#define NES_MSG_HEIGHT	11		// message text height of window, 4 rows height 32, 7 rows height 16
-#define NES_MSG_BTMLINE	(4*32)		// bottom line to start 16-line rows
+#define NES_MSG_WIDTH   (WIDTH*16/240)  // message text width (~5% smaller, ~15 px per char)
+#define NES_MSG_HEIGHT  11              // message text height of window, 4 rows height 32, 7 rows height 16
+#define NES_MSG_BTMLINE (4*32)          // bottom line to start 16-line rows
 
-// text scale in percent (100 = original size)
-#define NES_TEXT_SCALE	95
-
-// text screen buffer (only characters; 160 bytes)
+// text screen buffer (only characters; 176 bytes)
 extern u8 NES_TextFrame[NES_MSG_WIDTH*NES_MSG_HEIGHT];
 
 // colors of rows

--- a/PicoPad/EMU/NES/src/emu_nes_msg.h
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.h
@@ -27,7 +27,7 @@
 #define NES_LCD_HEIGHT  HEIGHT
 #endif
 #define NES_MSG_WIDTH   (NES_LCD_WIDTH*16/240) // message text width (16 columns)
-#define NES_TEXT_SCALE  80                      // horizontal text scale in percent (100 = original size, 80 = 20% smaller)
+#define NES_TEXT_SCALE  80                      // text scale in percent (100 = original size, 80 = 20% smaller)
 #define NES_MSG_HEIGHT  11                     // message text height of window, 4 rows height 32, 7 rows height 16
 #define NES_MSG_BTMLINE (4*32)                 // bottom line to start 16-line rows
 

--- a/PicoPad/EMU/NES/src/emu_nes_msg.h
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.h
@@ -27,7 +27,7 @@
 #define NES_LCD_HEIGHT  HEIGHT
 #endif
 #define NES_MSG_WIDTH   (NES_LCD_WIDTH*16/240) // message text width (16 columns)
-#define NES_TEXT_SCALE  95                      // horizontal text scale in percent (100 = original size)
+#define NES_TEXT_SCALE  80                      // horizontal text scale in percent (100 = original size, 80 = 20% smaller)
 #define NES_MSG_HEIGHT  11                     // message text height of window, 4 rows height 32, 7 rows height 16
 #define NES_MSG_BTMLINE (4*32)                 // bottom line to start 16-line rows
 

--- a/PicoPad/EMU/NES/src/emu_nes_msg.h
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.h
@@ -26,8 +26,8 @@
 #else
 #define NES_LCD_HEIGHT  HEIGHT
 #endif
-
-#define NES_MSG_WIDTH   (NES_LCD_WIDTH*16/240) // message text width (~5% smaller, ~15 px per char)
+#define NES_MSG_WIDTH   (NES_LCD_WIDTH*16/240) // message text width (16 columns)
+#define NES_TEXT_SCALE  95                      // horizontal text scale in percent (100 = original size)
 #define NES_MSG_HEIGHT  11                     // message text height of window, 4 rows height 32, 7 rows height 16
 #define NES_MSG_BTMLINE (4*32)                 // bottom line to start 16-line rows
 


### PR DESCRIPTION
## Summary
- Add `NES_TEXT_SCALE` to allow adjusting menu text size for smaller displays
- Apply 5% horizontal font reduction in `NES_TextUpdate` and pad lines accordingly

## Testing
- ⚠️ `make` *(no makefile found)*
- ⚠️ `bash _c1.sh` *(no rule to make target 'all')*

------
https://chatgpt.com/codex/tasks/task_e_68a2bf787a3483239e44ac6f9d7490b8