### PR TITLE
Expand NES menu text area and left-align

### DIFF
--- a/PicoPad/EMU/NES/src/emu_nes_msg.cpp
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.cpp
@@ -134,10 +134,9 @@ void NES_TextUpdate()
         u8* s2;
         const u8* f = FontBold8x16;
         u16 bg = NES_TextBgColor;
-        int scaled = EMU_LCD_WIDTH * NES_TEXT_SCALE / 100;
+        int scaled = EMU_LCD_WIDTH;
         int pad = EMU_LCD_WIDTH - scaled;
-        int padleft = pad/2;
-        int padright = pad - padleft;
+        int padright = pad;
         int rep = scaled / (NES_MSG_WIDTH*8);
         int rem = scaled % (NES_MSG_WIDTH*8);
 
@@ -151,7 +150,7 @@ void NES_TextUpdate()
                 s2 = s; // start of text row
                 int acc = 0;
 
-                for (int n = padleft; n > 0; n--) DispSendImg2(bg);
+                // no left padding to keep text aligned to the left
 
                 // columns
                 for (col = 0; col < NES_MSG_WIDTH; col++)

--- a/PicoPad/EMU/NES/src/emu_nes_msg.h
+++ b/PicoPad/EMU/NES/src/emu_nes_msg.h
@@ -26,8 +26,8 @@
 #else
 #define NES_LCD_HEIGHT  HEIGHT
 #endif
-#define NES_MSG_WIDTH   (NES_LCD_WIDTH*16/240) // message text width (16 columns)
-#define NES_TEXT_SCALE  80                      // horizontal text scale in percent (100 = original size, 80 = 20% smaller)
+#define NES_MSG_WIDTH   (NES_LCD_WIDTH*21/240) // message text width (21 columns)
+#define NES_TEXT_SCALE  100                     // horizontal text scale in percent (100 = original size, 80 = 20% smaller)
 #define NES_MSG_HEIGHT  11                     // message text height of window, 4 rows height 32, 7 rows height 16
 #define NES_MSG_BTMLINE (4*32)                 // bottom line to start 16-line rows
 


### PR DESCRIPTION
## Summary
- widen NES menu text to 21 columns and drop horizontal scaling to use full 240px width
- remove left padding in NES_TextUpdate so menu messages start at column 0

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `./c.bat` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f12d651883238f06eddfca172f8a