### PR TITLE
Use Bresenham cadence for GBC screen scaling

### DIFF
--- a/PicoPad/EMU/GBC/Readme.txt
+++ b/PicoPad/EMU/GBC/Readme.txt
@@ -1,0 +1,12 @@
+Game Boy Color emulator for PicoPad.
+
+Screen Scaling
+--------------
+The Game Boy frame buffer is 160x144 while the target display is 240x240.
+Scaling is performed with a fixed Bresenham-style cadence without filtering.
+
+- Horizontal 2→3: each pair of source pixels expands to three destination pixels using the pattern [S0,S0,S1].
+- Vertical 3→5: each trio of source rows expands to five destination rows using the pattern [R0,R1,R1,R2,R2].
+
+The algorithm uses only additions and comparisons, making it very fast and
+keeping the image geometry unchanged.

--- a/PicoPad/EMU/GBC/src/main.cpp
+++ b/PicoPad/EMU/GBC/src/main.cpp
@@ -1082,9 +1082,33 @@ void GB_Setup()
 
 	// clear context
 	memset(&gbContext, 0, sizeof(gbContext));
-        for (int i = 0; i < WIDTH; i++) lut_x[i] = (i * LCD_WIDTH) / WIDTH;
-        for (int j = 0; j < HEIGHT; j++) lut_y[j] = (j * LCD_HEIGHT) / HEIGHT;
-
+	// generate scaling lookup tables using Bresenham-style cadence
+	// X: 160->240 (2->3) produces pattern [S0,S0,S1]
+	int err = 0;
+	int src = 0;
+	for (int dst = 0; dst < WIDTH; dst++)
+	{
+		lut_x[dst] = src;
+		err += LCD_WIDTH;
+		if (err >= WIDTH)
+		{
+			err -= WIDTH;
+			src++;
+		}
+	}
+	// Y: 144->240 (3->5) produces pattern [R0,R1,R1,R2,R2]
+	err = HEIGHT - LCD_HEIGHT;
+	src = 0;
+	for (int dst = 0; dst < HEIGHT; dst++)
+	{
+		lut_y[dst] = src;
+		err += LCD_HEIGHT;
+		if (err >= HEIGHT)
+		{
+			err -= HEIGHT;
+			src++;
+		}
+	}
 	// select colorization palette
 	gbSelectColorizationPalette();
 

--- a/tests/gbc_scaling_test.c
+++ b/tests/gbc_scaling_test.c
@@ -1,0 +1,50 @@
+#include <assert.h>
+#include <stdio.h>
+
+#define LCD_WIDTH 160
+#define LCD_HEIGHT 144
+#define WIDTH 240
+#define HEIGHT 240
+
+int main(void) {
+    unsigned char lut_x[WIDTH];
+    unsigned char lut_y[HEIGHT];
+
+    int err = 0;
+    int src = 0;
+    for (int dst = 0; dst < WIDTH; dst++) {
+        lut_x[dst] = src;
+        err += LCD_WIDTH;
+        if (err >= WIDTH) {
+            err -= WIDTH;
+            src++;
+        }
+    }
+
+    err = HEIGHT - LCD_HEIGHT;
+    src = 0;
+    for (int dst = 0; dst < HEIGHT; dst++) {
+        lut_y[dst] = src;
+        err += LCD_HEIGHT;
+        if (err >= HEIGHT) {
+            err -= HEIGHT;
+            src++;
+        }
+    }
+
+    unsigned char expected_x[] = {0, 0, 1};
+    for (int i = 0; i < 3; i++) {
+        assert(lut_x[i] == expected_x[i]);
+    }
+
+    unsigned char expected_y[] = {0, 1, 1, 2, 2};
+    for (int i = 0; i < 5; i++) {
+        assert(lut_y[i] == expected_y[i]);
+    }
+
+    assert(lut_x[WIDTH - 1] == LCD_WIDTH - 1);
+    assert(lut_y[HEIGHT - 1] == LCD_HEIGHT - 1);
+
+    printf("OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace division-based lookup tables with Bresenham-style cadence for pixel/row duplication
- document new scaling method and patterns
- add test ensuring LUT patterns match expected sequences

## Testing
- `gcc tests/gbc_scaling_test.c -o tests/gbc_scaling_test`
- `./tests/gbc_scaling_test`


------
https://chatgpt.com/codex/tasks/task_e_68abe2623b208323aa69b84a9c726abd